### PR TITLE
fix navbar padding issue for screens between 1280 and 1530

### DIFF
--- a/code/resources/assets/sass/app.scss
+++ b/code/resources/assets/sass/app.scss
@@ -1,5 +1,5 @@
 body {
-	padding-top: 70px;
+	padding-top: 0 !important;
 }
 
 @media (max-width: 1280px) and (min-width: 751px) {

--- a/code/resources/views/app.blade.php
+++ b/code/resources/views/app.blade.php
@@ -43,7 +43,7 @@
             <img src="{{ asset('images/loading.svg') }}" alt="{{ _i('Caricamento in corso') }}">
         </div>
 
-        <nav class="navbar navbar-default navbar-fixed-top navbar-inverse">
+        <nav class="navbar navbar-default navbar-static-top navbar-inverse">
             <div class="container-fluid">
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">

--- a/code/resources/views/errors/404.blade.php
+++ b/code/resources/views/errors/404.blade.php
@@ -10,7 +10,7 @@
         <link rel="stylesheet" type="text/css" href="{{ url('/css/bootstrap.min.css') }}">
     </head>
     <body>
-        <nav class="navbar navbar-default navbar-fixed-top navbar-inverse">
+        <nav class="navbar navbar-default navbar-static-top navbar-inverse">
             <div class="container-fluid">
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">

--- a/code/resources/views/errors/500.blade.php
+++ b/code/resources/views/errors/500.blade.php
@@ -10,7 +10,7 @@
         <link rel="stylesheet" type="text/css" href="{{ url('/css/bootstrap.min.css') }}">
     </head>
     <body>
-        <nav class="navbar navbar-default navbar-fixed-top navbar-inverse">
+        <nav class="navbar navbar-default navbar-static-top navbar-inverse">
             <div class="container-fluid">
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">

--- a/code/resources/views/errors/503.blade.php
+++ b/code/resources/views/errors/503.blade.php
@@ -10,7 +10,7 @@
         <link rel="stylesheet" type="text/css" href="{{ url('/css/bootstrap.min.css') }}">
     </head>
     <body>
-        <nav class="navbar navbar-default navbar-fixed-top navbar-inverse">
+        <nav class="navbar navbar-default navbar-static-top navbar-inverse">
             <div class="container-fluid">
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">


### PR DESCRIPTION
Given the overlay issue that was happeing somethins (see below)

![screenshot 32](https://user-images.githubusercontent.com/10962296/49504630-5c1e7a80-f87a-11e8-8923-911fc7439b87.png)


1) I have replaced the `navbar-fixed-top` class with the `navbar-static-top` in all `nav` tags
2) I have set the `padding-top` property to` 0 !important` for the `body`