### PR TITLE
Gestione null di gas durante la prima installazione

### DIFF
--- a/code/app/Helpers/Permissions.php
+++ b/code/app/Helpers/Permissions.php
@@ -42,10 +42,13 @@ function allPermissions()
     */
     try {
         $gas = currentAbsoluteGas();
-        $gas = $gas->fresh();
 
-        if ($gas->multigas) {
-            $ret['App\Gas']['gas.multi'] = _i('Amministrare la modalità Multi-GAS su questa istanza');
+        if (isset($gas)) {
+            $gas = $gas->fresh();
+
+            if ($gas->multigas) {
+                $ret['App\Gas']['gas.multi'] = _i('Amministrare la modalità Multi-GAS su questa istanza');
+            }
         }
     }
     catch(\Exception $e) {


### PR DESCRIPTION
Durante prima installazione, **$gas** è **null** in `currentAbsoluteGas()` alla linea 44, impedendo l'esecuzione di `$gas->fresh()` (errore: `Call to a member function fresh() on null`).