### PR TITLE
 php a 8.2

### DIFF
--- a/code/composer.json
+++ b/code/composer.json
@@ -5,7 +5,7 @@
     "license": "AGPL-3.0+",
     "type": "project",
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "ext-gd": "*",
         "aws/aws-php-sns-message-validator": "^1.5",
         "aws/aws-sdk-php": "^3.67",


### PR DESCRIPTION
Aggiorna la versione minima di  PHP a 8.2 per garantire compatibilità con Laravel 11.