### PR TITLE
Risolto errore di migrazione dovuto a after() in Schema::create()

### DIFF
--- a/code/database/migrations/2020_04_28_011017_create_modifier_types_table.php
+++ b/code/database/migrations/2020_04_28_011017_create_modifier_types_table.php
@@ -12,8 +12,8 @@ class CreateModifierTypesTable extends Migration
             $table->timestamps();
 
             $table->string('name');
-            $table->string('identifier')->default('')->after('system');
             $table->boolean('system')->default(false);
+            $table->string('identifier')->default('');
             $table->boolean('active')->default(true);
             $table->text('classes');
             $table->boolean('hidden')->default(false);


### PR DESCRIPTION
Durante una nuova installazione o l'esecuzione di `php artisan migrate:fresh`, si verifica un errore SQL nella migrazione a causa dell'uso di `after()` all'interno di `Schema::create()`. Ho testato il problema con diverse versioni di MariaDB e MySQL, e l'errore persiste.

![Screenshot From 2025-03-30 07-59-22](https://github.com/user-attachments/assets/08e75316-ed25-43de-b95e-3f5d88980b9f)

Sembra che il metodo `after()` non è supportato in `Schema::create()`, poiché genera una clausola SQL AFTER valida solo per `Schema::table()` (modifica di tabelle esistenti), non per la creazione di nuove tabelle.
Ho rimosso `after()` dalla migrazione e riordinato le colonne direttamente nel blocco `Schema::create()` per mantenere la sequenza desiderata. Questo elimina l'errore e permette alla migrazione di funzionare correttamente.