### PR TITLE
#46 esportazione grafici statistiche come immagine

### DIFF
--- a/code/resources/assets/js/statistics.js
+++ b/code/resources/assets/js/statistics.js
@@ -51,7 +51,12 @@ class Statistics {
         else {
             if ($(selector).length != 0) {
                 $(selector).empty().css('height', data.labels.length * 40);
-                new BarChart(selector, data, this.commonGraphConfig());
+                const chart = new BarChart(selector, data, this.commonGraphConfig());
+
+                chart.on('created', (data) => {
+                    const el = this.addBootstrapDropdown(selector);
+                    this.addDownloadButtons(data.svg['_node'], el, selector);
+                });
             }
         }
     }
@@ -100,6 +105,143 @@ class Statistics {
             this.doGraphs('products', data);
         });
     }
+
+    static addBootstrapDropdown(selector) 
+    {
+        const container = document.createElement('div');
+        container.className = 'dropdown';
+
+        const btn = document.createElement('button');
+        btn.classList.add('btn', 'btn-light', 'form-download');
+        btn.type = 'button';
+        btn.innerText = 'Esporta ';
+        btn.setAttribute('data-bs-toggle', 'dropdown');
+        btn.setAttribute('aria-expanded', 'false');
+        container.appendChild(btn);
+
+        const i = document.createElement('i');
+        i.className = 'bi-download';
+        btn.appendChild(i);
+
+        const ul = document.createElement('ul');
+        ul.className = 'dropdown-menu';
+        container.appendChild(ul);
+
+        $(selector).prev().append(container);   
+        
+        return ul;
+    }
+
+    static async addDownloadButtons(svg, root, filename) 
+    {
+        const url = await svgToImage(svg);
+
+        for (const type in url) {
+            const li = document.createElement('li');
+            root.appendChild(li);
+
+            const firstLetter = type.charAt(0);
+            const a = document.createElement('a');
+            a.classList.add('dropdown-item', 'form-download');
+            a.href = url[type];
+            a.download = filename.replace('#', '') + '.' + type;
+            a.text = type.replace(firstLetter, firstLetter.toUpperCase());
+            li.appendChild(a);
+        }
+    }
 }
+
+function svgToImage(svgElement) 
+{
+    // 1. Clone the SVG to avoid messing with the live page
+    const clonedSvg = svgElement.cloneNode(true);
+
+    // 2. Load element classes to inline style 
+    inlineStyle(svgElement, clonedSvg);
+
+    // 3. Validate SVG
+    validateSVG(clonedSvg);
+
+    return new Promise((resolve, reject) => {
+        // 4. Serialize SVG and create URL
+        const svgData = new XMLSerializer().serializeToString(clonedSvg);
+        const base64Svg = toBase64(svgData);
+        const url = 'data:image/svg+xml;charset=utf-8;base64,' + base64Svg;
+
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.src = url;
+
+        img.onload = () => {
+            const canvas = document.createElement('canvas');
+            canvas.width = svgElement.clientWidth;
+            canvas.height = svgElement.clientHeight;
+
+            const ctx = canvas.getContext('2d');
+            ctx.fillStyle = "white";
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            ctx.drawImage(img, 0, 0);
+
+            const jpegUrl = canvas.toDataURL('image/jpeg');
+            const pngUrl = canvas.toDataURL('image/png');
+
+            URL.revokeObjectURL(url);
+            resolve({
+                'jpeg': jpegUrl, 
+                'png': pngUrl
+            });
+        }
+
+        img.onerror = (error) => {
+            URL.revokeObjectURL(url);
+            reject(error);
+        }
+    });
+}
+
+function toBase64(data) 
+{
+    // TextEncoder: Always UTF8
+    const uInt8Array = new TextEncoder().encode(data);
+    let binary = '';
+
+    for (let i = 0; i < uInt8Array.length; ++i)
+        binary += String.fromCharCode(uInt8Array[i]);
+
+    return btoa(binary);
+}
+
+function inlineStyle(original, clone) 
+{
+    // 1. Get all elements from both the original and the clone
+    const originalElements = original.querySelectorAll('*');
+    const clonedElements = clone.querySelectorAll('*');
+
+    // 2. Loop through and "bake" the computed styles
+    originalElements.forEach((el, i) => {
+        const computed = getComputedStyle(el);
+        const target = clonedElements[i];
+
+        // List of critical SVG styles to preserve
+        const styleProps = [
+            'fill', 'stroke', 'stroke-width', 'opacity', 
+            'display', 'font-family', 'font-size', 'stop-color'
+        ];
+
+        styleProps.forEach(prop => {
+            target.style[prop] = computed.getPropertyValue(prop);
+        });
+    });
+}
+
+function validateSVG(svg) 
+{
+    const elements = svg.querySelectorAll('*');
+    elements.forEach(el => {
+        if(el instanceof HTMLElement) {
+            el.removeAttribute('xmlns');
+        }
+    })
+} 
 
 export default Statistics;

--- a/code/resources/assets/js/statistics.js
+++ b/code/resources/assets/js/statistics.js
@@ -54,8 +54,7 @@ class Statistics {
                 const chart = new BarChart(selector, data, this.commonGraphConfig());
 
                 chart.on('created', (data) => {
-                    const el = this.addBootstrapDropdown(selector);
-                    this.addDownloadButtons(data.svg['_node'], el, selector);
+                    this.addDownloadButtons(data.svg['_node'], selector);
                 });
             }
         }
@@ -106,7 +105,7 @@ class Statistics {
         });
     }
 
-    static addBootstrapDropdown(selector) 
+    /* static addBootstrapDropdown(selector) 
     {
         const container = document.createElement('div');
         container.className = 'dropdown';
@@ -130,39 +129,51 @@ class Statistics {
         $(selector).prev().append(container);   
         
         return ul;
-    }
+    } */
 
-    static async addDownloadButtons(svg, root, filename) 
+    static async addDownloadButtons(svg, selector) 
     {
         const url = await svgToImage(svg);
-
-        for (const type in url) {
+        
+        /* for (const type in url) {
             const li = document.createElement('li');
             root.appendChild(li);
 
-            const firstLetter = type.charAt(0);
+            // const firstLetter = type.charAt(0);
             const a = document.createElement('a');
             a.classList.add('dropdown-item', 'form-download');
             a.href = url[type];
             a.download = filename.replace('#', '') + '.' + type;
             a.text = type.replace(firstLetter, firstLetter.toUpperCase());
             li.appendChild(a);
-        }
+        } */
+
+        const a = document.createElement('a');
+        a.classList.add('btn', 'btn-light', 'form-download');
+        a.href = url;
+        a.download = selector.replace('#', '') + '.jpeg';
+        a.text = 'Esporta ';
+
+        const i = document.createElement('i');
+        i.className = 'bi-download';
+        a.append(i);
+
+        $(selector).prev().append(a);
     }
 }
 
 function svgToImage(svgElement) 
 {
-    // 1. Clone the SVG to avoid messing with the live page
-    const clonedSvg = svgElement.cloneNode(true);
-
-    // 2. Load element classes to inline style 
-    inlineStyle(svgElement, clonedSvg);
-
-    // 3. Validate SVG
-    validateSVG(clonedSvg);
-
     return new Promise((resolve, reject) => {
+        // 1. Clone the SVG to avoid messing with the live page
+        const clonedSvg = svgElement.cloneNode(true);
+
+        // 2. Load element classes to inline style 
+        inlineStyle(svgElement, clonedSvg);
+
+        // 3. Validate SVG
+        validateSVG(clonedSvg);
+
         // 4. Serialize SVG and create URL
         const svgData = new XMLSerializer().serializeToString(clonedSvg);
         const base64Svg = toBase64(svgData);
@@ -181,15 +192,17 @@ function svgToImage(svgElement)
             ctx.fillStyle = "white";
             ctx.fillRect(0, 0, canvas.width, canvas.height);
             ctx.drawImage(img, 0, 0);
+            
+            // const jpegUrl = canvas.toDataURL('image/jpeg');
+            // const pngUrl = canvas.toDataURL('image/png');
 
-            const jpegUrl = canvas.toDataURL('image/jpeg');
-            const pngUrl = canvas.toDataURL('image/png');
+            const dataUrl = canvas.toDataURL('image/jpeg');
 
             URL.revokeObjectURL(url);
-            resolve({
+            resolve(dataUrl /* {
                 'jpeg': jpegUrl, 
                 'png': pngUrl
-            });
+            } */);
         }
 
         img.onerror = (error) => {

--- a/code/resources/views/commons/statspage.blade.php
+++ b/code/resources/views/commons/statspage.blade.php
@@ -36,19 +36,25 @@ else {
 
         <div class="row">
             <div class="col-lg mb-2">
-                <h4>{{ __('texts.generic.value') }}</h4>
+                <div class="row row-cols-auto">
+                    <h4>{{ __('texts.generic.value') }}</h4>
+                </div>
                 <div class="ct-chart-bar" id="stats-generic-expenses"></div>
             </div>
 
 			@if(is_a($target, \App\User::class) == false)
 	            <div class="col-lg mb-2">
-	                <h4>{{ __('texts.user.all') }}</h4>
+                    <div class="row row-cols-auto">
+                        <h4>{{ __('texts.user.all') }}</h4>
+                    </div>
 	                <div class="ct-chart-bar" id="stats-generic-users"></div>
 	            </div>
 			@endif
 
             <div class="col-lg mb-2">
-                <h4>{{ __('texts.generic.categories') }}</h4>
+                <div class="row row-cols-auto">
+                    <h4>{{ __('texts.generic.categories') }}</h4>
+                </div>
                 <div class="ct-chart-bar" id="stats-generic-categories"></div>
             </div>
         </div>
@@ -82,19 +88,25 @@ else {
 
         <div class="row">
             <div class="col-lg mb-2">
-                <h4>{{ __('texts.generic.value') }}</h4>
+                <div class="row row-cols-auto">
+                    <h4>{{ __('texts.generic.value') }}</h4>
+                </div>
                 <div class="ct-chart-bar" id="stats-products-expenses"></div>
             </div>
 
 			@if(is_a($target, \App\User::class) == false)
 	            <div class="col-lg mb-2">
-	                <h4>{{ __('texts.user.all') }}</h4>
+                    <div class="row row-cols-auto">
+    	                <h4>{{ __('texts.user.all') }}</h4>
+                    </div>
 	                <div class="ct-chart-bar" id="stats-products-users"></div>
 	            </div>
 			@endif
 
             <div class="col-lg mb-2">
-                <h4>{{ __('texts.generic.categories') }}</h4>
+                <div class="row row-cols-auto">
+                    <h4>{{ __('texts.generic.categories') }}</h4>
+                </div>
                 <div class="ct-chart-bar" id="stats-products-categories"></div>
             </div>
         </div>


### PR DESCRIPTION
Alla fine ho deciso di semplificare l'esperienza utente rendendo possibile il download del grafico solo in formato jpeg, così da evitare confusione per chi non conoscesse le differenze tra jpeg e png.

Ho preferito lasciare del codice commentato così che nel caso tu voglia mantenere l'opzione con il download nei due formati, puoi sempre rigettare la PR in modo che ripristino la situazione precedente. 

In caso contrario eliminare il codice commentato nel file statistics.js e comunque sentiti libero di aggiungere dei commenti alle funzioni aggiunte oppure di ricollocarle in base alla struttura del progetto.

Per qualsiasi cosa, ci sentiamo nella issue #46. 
Ciao